### PR TITLE
Add v0 and auto-tagging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rewindio/devops

--- a/.github/workflows/publish-and-deploy.yml
+++ b/.github/workflows/publish-and-deploy.yml
@@ -47,6 +47,10 @@ on:
         required: false
         type: string
         default: .
+      docker_target:
+        description: "The target to build"
+        required: false
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         description: "The AWS Access Key ID used during publish and deploy."
@@ -113,6 +117,7 @@ jobs:
           platforms: linux/amd64
           push: ${{ inputs.ecr_push }}
           tags: ${{ steps.meta.outputs.tags }}
+          target: ${{ inputs.docker_target }}
 
   deploy:
     name: 'Deploy (${{ inputs.ecs_service_name }})'

--- a/.github/workflows/publish-and-deploy.yml
+++ b/.github/workflows/publish-and-deploy.yml
@@ -1,0 +1,156 @@
+name: Terraform Apply
+
+on:
+  workflow_call:
+    inputs:
+      aws_region:
+        description: "The AWS Region to deploy to"
+        required: true
+        type: string
+      ecs_cluster_name:
+        description: "Name of an existing ECS Cluster"
+        required: true
+        type: string
+      ecs_service_name:
+        description: "Name of an existing ECS Service"
+        required: true
+        type: string
+      ecs_task_definition:
+        description: "Name of an existing ECS Task definition"
+        required: true
+        type: string
+      ecr_repository:
+        description: "Name of an existing ECR repository"
+        required: true
+        type: string
+      ecs_container_definition:
+        description: "Name of an existing container definition within the specified task definition"
+        required: true
+        type: string
+      ecs_deploy:
+        description: "Whether or not to deploy the rendered task definition to ECS."
+        required: true
+        default: false
+        type: boolean
+      ecr_push:
+        description: "Whether or not to push the image to ECR."
+        required: true
+        default: false
+        type: boolean
+      docker_file_path:
+        description: "The path to the Dockerfile"
+        required: false
+        type: string
+        default: ./Dockerfile
+      docker_context_path:
+        description: "The path to the docker context"
+        required: false
+        type: string
+        default: .
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        description: "The AWS Access Key ID used during publish and deploy."
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        description: "The AWS Secret Access Key used during publish and deploy."
+        required: true
+
+jobs:
+
+  build-and-publish:
+    name: 'Build & Publish (${{ inputs.ecs_service_name }})'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "${{ inputs.aws_region }}"
+          mask-aws-account-id: 'no'
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository }}"
+          tags: |
+            type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build and push to ECR
+        uses: docker/build-push-action@v2
+        with:
+          # All layers should be cached to optimize for multi-environment deploys
+          # Can't cache locally. Blocked by https://github.com/docker/build-push-action/issues/252
+          #cache-from: type=local,src=/tmp/.buildx-cache
+          #cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha,src=/tmp/.buildx-cache
+          cache-to: type=gha,dest=/tmp/.buildx-cache-new
+          context: "${{ inputs.docker_context_path }}"
+          file: "${{ inputs.docker_file_path }}"
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          push: ${{ inputs.ecr_push }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+  deploy:
+    name: 'Deploy (${{ inputs.ecs_service_name }})'
+    needs: [build-and-publish]
+    runs-on: ubuntu-latest
+    if: ${{ inputs.ecs_deploy }}
+
+    steps:
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: "${{ inputs.aws_region }}"
+
+      - name: Download task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ inputs.ecs_task_definition }} \
+            --query taskDefinition > task-definition.json
+
+      - name: Render Amazon ECS task definition
+        id: render-web-container
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ inputs.ecs_container_definition }}
+          image: ${{ needs.build-and-publish.outputs.tag }}
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.render-web-container.outputs.task-definition }}
+          service: "${{ inputs.ecs_service_name }}"
+          cluster: "${{ inputs.ecs_cluster_name }}"
+          wait-for-service-stability: true

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,47 @@
+name: Tag version
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+      - '*.md'
+      - 'LICENSE'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MAJOR_VERSION: 0
+      MINOR_VERSION: 1
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Remove tag for major version
+        uses: actions/github-script@v5
+        continue-on-error: true
+        with:
+          script: |
+            github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'tags/v' + process.env.MAJOR_VERSION,
+            })
+      - name: Create tag for major version
+        if: always()
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v' + process.env.MAJOR_VERSION,
+              sha: context.sha
+            })
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch
+          INITIAL_VERSION: ${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # github-action-ecs-deploy
+
+This is a reusable workflow that both publishes images to ECR and deploys them to ECS.
+
+This deployment is opinionated and only renders a single container definition at a time. Rendering multiple container definitions in a single deploy is possible but challenging given the constraints of reusable workflows in GitHub Actions.
+
+## Example usage
+
+```yaml
+name: ECS
+concurrency: ecs
+
+on:
+  push:
+
+jobs:
+  deploy:
+    name: "ECR-ECS"
+    uses: rewindio/github-action-ecs-deploy/.github/workflows/publish-and-deploy.yml@v0
+    with:
+      aws_region: ca-central-1
+      ecs_cluster_name: my-cluster
+      ecs_service_name: my-Service-6XXXMsrEhjXH
+      ecs_task_definition: my-task-definition
+      ecs_container_definition: my-container-definition
+      ecr_repository: my-ecr-repo-name
+      ecr_push: ${{ github.ref == 'refs/heads/main' }}
+      ecs_deploy: ${{ github.ref == 'refs/heads/main' }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+


### PR DESCRIPTION
This is a reusable workflow that both publishes images to ECR and deploys them to ECS.

This deployment is opinionated and only renders a single container definition at a time.

Rendering multiple container definitions in a single deploy is possible but challenging given the constraints of reusable workflows in GitHub Actions.

Since sidecar containers can be managed in terraform, this reusable should work for common path.
