### PR TITLE
Replace amazon-ecs-render-task-definition with terraform

### DIFF
--- a/.github/workflows/publish-and-deploy.yml
+++ b/.github/workflows/publish-and-deploy.yml
@@ -4,39 +4,18 @@ on:
   workflow_call:
     inputs:
       deploy_matrix:
-        description: "A JSON list of objects, specifying the region and any additional deployment parameters"
+        description: "A JSON list of objects, each specifying the region, ecr_repository and workspace (terraform)."
         required: true
         type: string
-      ecs_cluster_name:
-        description: "Name of an existing ECS Cluster"
+      profile:
+        description: "The AWS profile to use"
         required: true
         type: string
-      ecs_service_name:
-        description: "Name of an existing ECS Service"
-        required: true
+      terraform_dir:
+        description: "The path to the terraform files"
+        required: false
         type: string
-      ecs_task_definition:
-        description: "Name of an existing ECS Task definition"
-        required: true
-        type: string
-      ecr_repository:
-        description: "Name of an existing ECR repository"
-        required: true
-        type: string
-      ecs_container_definition:
-        description: "Name of an existing container definition within the specified task definition"
-        required: true
-        type: string
-      ecs_deploy:
-        description: "Whether or not to deploy the rendered task definition to ECS."
-        required: true
-        default: false
-        type: boolean
-      ecr_push:
-        description: "Whether or not to push the image to ECR."
-        required: true
-        default: false
-        type: boolean
+        default: ./terraform
       docker_file_path:
         description: "The path to the Dockerfile"
         required: false
@@ -58,6 +37,9 @@ on:
       AWS_SECRET_ACCESS_KEY:
         description: "The AWS Secret Access Key used during publish and deploy."
         required: true
+      GITHUB_PAT:
+        description: "A GitHub access token that has repo and read:packages scopes"
+        required: false
       BUILD_ARGS:
         description: "Docker image build arguments"
         required: false
@@ -65,7 +47,7 @@ on:
 jobs:
 
   build-and-publish:
-    name: 'Build & Publish (${{ inputs.ecs_service_name }})'
+    name: 'Build & Publish'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -94,7 +76,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: "${{ steps.login-ecr.outputs.registry }}/${{ inputs.ecr_repository }}"
+          images: "${{ steps.login-ecr.outputs.registry }}/${{ matrix.ecr_repository }}"
           tags: |
             type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
 
@@ -122,22 +104,30 @@ jobs:
           file: "${{ inputs.docker_file_path }}"
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          push: ${{ inputs.ecr_push }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           target: ${{ inputs.docker_target }}
           build-args: ${{ secrets.BUILD_ARGS }}
 
   deploy:
-    name: 'Deploy (${{ inputs.ecs_service_name }})'
+    name: 'Deploy' 
     needs: [build-and-publish]
     runs-on: ubuntu-latest
-    if: ${{ inputs.ecs_deploy }}
+    if: github.ref == 'refs/heads/main'
+    strategy:
+      matrix:
+        include:
+          ${{ fromJson(inputs.deploy_matrix) }}
+    env:
+      AWS_SHARED_CREDENTIALS_FILE: /tmp/ac
 
     steps:
 
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.ref }}
+          submodules: 'true'
+          token: ${{ secrets.GITHUB_PAT }} # Needed for private submodules
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -146,24 +136,58 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: "${{ matrix.region }}"
 
-      - name: Download task definition
+      - name: Set terraform workspace
+        run: echo TF_WORKSPACE="${{ matrix.workspace }}" >> $GITHUB_ENV
+
+      - name: Set varfile
+        id: tfvars
         run: |
-          aws ecs describe-task-definition \
-            --task-definition ${{ inputs.ecs_task_definition }} \
-            --query taskDefinition > task-definition.json
+          echo "::set-output name=tfvar_file::tfvars/${{ inputs.profile }}/${{ matrix.workspace }}.tfvars"
 
-      - name: Render Amazon ECS task definition
-        id: render-web-container
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: task-definition.json
-          container-name: ${{ inputs.ecs_container_definition }}
-          image: ${{ needs.build-and-publish.outputs.tag }}
+      # Allow for private terraform modules to be initialized
+      - name: Setup Git Config
+        run: |
+          git config --global \
+            url."https://oauth2:${{ secrets.GITHUB_PAT }}@github.com".insteadOf https://github.com
 
-      - name: Deploy to ECS
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      - name: Setup AWS credentials
+        run: |
+          cat <<EOF >> "$AWS_SHARED_CREDENTIALS_FILE"
+          [${{ inputs.profile }}]
+          aws_access_key_id = ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key = ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          EOF
+
+      - name: Set terraform version
+        id: set-terraform-version
+        run: echo "::set-output name=terraform-version::$(cat .terraform-version)"
+
+      - name: Terraform Setup
+        uses: hashicorp/setup-terraform@v1
         with:
-          task-definition: ${{ steps.render-web-container.outputs.task-definition }}
-          service: "${{ inputs.ecs_service_name }}"
-          cluster: "${{ inputs.ecs_cluster_name }}"
-          wait-for-service-stability: true
+          terraform_version: ${{ steps.set-terraform-version.outputs.terraform-version}}
+          terraform_wrapper: false
+
+      - name: Terraform Init
+        id: init
+        working-directory: ${{ inputs.terraform_dir }}
+        run: |
+          backend_file=backend/${{ inputs.profile }}.tfvars
+          echo "::set-output name=backend_file::$backend_file"
+          terraform init -backend-config "$backend_file"
+
+      - name: Terraform Apply
+        id: apply
+        working-directory: ${{ inputs.terraform_dir }}
+        run: |
+          set -xo pipefail
+          terraform apply -no-color \
+            -var "app_image_reference=${{ needs.build-and-publish.outputs.tag }}" \
+            -var-file ${{ steps.init.outputs.backend_file }} \
+            -var-file ${{ steps.tfvars.outputs.tfvar_file }} \
+            -auto-approve |& tee terraform-${{ env.TF_WORKSPACE }}-apply-stdout.txt
+
+      - name: Cleanup AWS Credentials
+        if: always()
+        run: |
+          rm -f "$AWS_SHARED_CREDENTIALS_FILE"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAJOR_VERSION: 0
-      MINOR_VERSION: 1
+      MINOR_VERSION: 2
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # github-action-ecs-deploy
 
-This is a reusable workflow that both publishes images to ECR and deploys them to ECS.
-
-This deployment is opinionated and only renders a single container definition at a time. Rendering multiple container definitions in a single deploy is possible but challenging given the constraints of reusable workflows in GitHub Actions.
+This is a reusable workflow that both publishes images to ECR and deploys them to ECS via terraform.
 
 ## Example usage
 
@@ -15,19 +13,19 @@ on:
 
 jobs:
   deploy:
-    name: "ECR-ECS"
+    name: "ECS-ECR"
     uses: rewindio/github-action-ecs-deploy/.github/workflows/publish-and-deploy.yml@v0
     with:
-      deploy_matrix: '[ { region: "us-east-1" }, { region: "us-east-2" } ]'
-      ecs_cluster_name: my-cluster
-      ecs_service_name: my-Service-6XXXMsrEhjXH
-      ecs_task_definition: my-task-definition
-      ecs_container_definition: my-container-definition
-      ecr_repository: my-ecr-repo-name
-      ecr_push: ${{ github.ref == 'refs/heads/main' }}
-      ecs_deploy: ${{ github.ref == 'refs/heads/main' }}
+      deploy_matrix: |
+        [
+          { "region": "us-east-1", "workspace": "my-workspace-1", "ecr_repository": "test-repo-1" },
+          { "region": "us-east-1", "workspace": "my-workspace-2", "ecr_repository": "test-repo-2" },
+        ]
+      profile: staging
+      terraform_dir: .
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
 ```
 


### PR DESCRIPTION
[amazon-ecs-render-task-definition](https://github.com/aws-actions/amazon-ecs-render-task-definition) causes more problems than it solves
due to managing task definitions in two different places.

This cleans up several inputs and bumps the version to 0.2.x

Tested here:
https://github.com/rewindio/terraform-ecs-rails-test/blob/a31e949e42cb69321229f36d17528efaf7687f2a/.github/workflows/deployment.yml